### PR TITLE
Add function to read calibration matrix from file 

### DIFF
--- a/tests/testCalibMatricesIO.m
+++ b/tests/testCalibMatricesIO.m
@@ -1,0 +1,6 @@
+% Test to make sure that readCalibMat and writeCalibMat are one the inverse
+% of the another (to complete)
+
+calibMat1 = readCalibMat('../data/sensorCalibMatrices/matrix_SN026.txt');
+writeCalibMat(calibMat1,'./calibMatTest.txt');
+calibMat2 = readCalibMat('.calibdMatTest.txt');

--- a/utils/convert_onedotfifteen.m
+++ b/utils/convert_onedotfifteen.m
@@ -1,0 +1,15 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%
+% Function to convert a decimal number into 1.15 hex format
+function [hex_out] = convert_onedotfifteen(indecimal)
+
+temp = indecimal; % Ensure positive number
+quant = abs(round((2^15)*-temp)); % Quantize to 15 bits and round to the nearest integer;
+
+if indecimal < 0 % i.e. negative
+quant = bitcmp(quant,16) + 1; % Take the 2's complement
+end
+
+hex_out=dec2hex(quant); % Convert the decimal number to hex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%

--- a/utils/estimateCalibMatrix.m
+++ b/utils/estimateCalibMatrix.m
@@ -1,4 +1,4 @@
-function [calibM]=estimateCalibMatrix(rawData,expectedWrench)
+function [calibM,full_scale]=estimateCalibMatrix(rawData,expectedWrench)
 [mb, nb] = size(expectedWrench);
 
 kIA = kron(eye(6), rawData);

--- a/utils/readCalibMat.m
+++ b/utils/readCalibMat.m
@@ -2,6 +2,11 @@ function [calibMat] = readCalibMat(filename)
 %read the calibration matrix delivered by the calibration procedure
 
 fid = fopen(filename);
+
+if( fid == -1 )
+    error(strcat('[ERROR] error in opening file ',filename))
+end
+
 format = '%X';
 vec=fscanf(fid,format);
 calibMat=reshape(vec(1:36),[6,6])';

--- a/utils/writeCalibMat.m
+++ b/utils/writeCalibMat.m
@@ -1,0 +1,56 @@
+function [] = writeCalibMat(calibMat, full_scale, filename)
+% WRITECALIBMAT Write on file the calibration matrix
+%
+% calibMat is a 6x6 calibration matrix that maps raw output of
+% 16-bit ADC connected to the strain gauges (going from 2^15 to 2^15-1) 
+% to the Force-Torque values, expressed in Newtons / Newton-meters . 
+%
+% full_scale is a 6 vector of the full scale for each channel of the F/T
+% sensor, expressed in Newtons (first three values) and Newton-meters (last
+% three values). 
+%
+% filename is the name of the file in which the calibration matrix will be
+% written . 
+%
+
+% logic copied from the write_matrix script in ftSensCalib repository
+max_Fx = full_scale(1);
+max_Fy = full_scale(2);
+max_Fz = full_scale(3);
+max_Tx = full_scale(4);
+max_Ty = full_scale(5);
+max_Tz = full_scale(6);
+
+Wf = diag([1/max_Fx 1/max_Fy 1/max_Fz 1/max_Tx 1/max_Ty 1/max_Tz]);
+maxRaw = 2^15-1;
+Ws = diag([1/maxRaw 1/maxRaw 1/maxRaw 1/maxRaw 1/maxRaw 1/maxRaw]);
+
+% Calibration matrix ready to be implemented into the firmware, maps 
+% the raw values to values expressed with respect to the fullscale of the
+% sensor 
+Cs = Wf * calibMat * inv(Ws);
+
+if(sum(sum(Cs>1))==0 && sum(sum(Cs<-1))==0)
+    disp('Matrix can be implemented in the DSP (i.e. coeffs in [-1 1])')
+else
+    disp('ERROR!!!! Matrix cannot be implemented in the DSP (i.e. coeffs not in [-1 1])')
+end
+
+fid = fopen(filename, 'w+');
+for iy=1:6
+    for ix=1:6
+        temp=convert_onedotfifteen(Cs(iy,ix));
+        fprintf(fid, '%s\r\n', temp);
+    end
+end
+fprintf(fid, '%d\r\n', 1);
+fprintf(fid, '%d\r\n', ceil(full_scale(1)));
+fprintf(fid, '%d\r\n', ceil(full_scale(2)));
+fprintf(fid, '%d\r\n', ceil(full_scale(3)));
+fprintf(fid, '%d\r\n', ceil(full_scale(4)));
+fprintf(fid, '%d\r\n', ceil(full_scale(5)));
+fprintf(fid, '%d\r\n', ceil(full_scale(6)));
+
+if fclose(fid) == -1
+   error('[ERROR] there was a problem in closing the file')
+end


### PR DESCRIPTION
I was looking into the code, and noticed this inconsistency : https://github.com/robotology-playground/insitu-ft-analysis/commit/fef8aed9e03ccd89ecb0c81669e1f7cd61246edf#commitcomment-16886903 . 
As already said here https://github.com/robotology-playground/insitu-ft-analysis/commit/fef8aed9e03ccd89ecb0c81669e1f7cd61246edf#commitcomment-16886684 I think it would be beneficial to always manipulate the calibration matrix in the code as the matrix mappings the raw values from - 2^15 to 2^15-1 to the F/T expressed in N / Nm , and leave the logic of conversion and scaling just in the `readCalibMat` / `writeCalibMat`functions. I implemented the `writeCalibMat` matching this logic, now you can modify also the `readCalibMat` function, and optionally use the testCalibMatricesIO.m (still to finish) to make sure that the two function are consistent one with another.